### PR TITLE
Wiz Remediate Vulnerabilities in: /go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/google/go-querystring v1.0.0
 	github.com/stretchr/testify v1.7.1
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/crypto v0.17.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
+	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
 )


### PR DESCRIPTION
Wiz has identified vulnerabilities in the following files: /go.mod. This PR contains remediations for these vulnerabilities.
### /go.mod
[CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565)
[CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948)
[CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795)
[CVE-2022-29526](https://nvd.nist.gov/vuln/detail/CVE-2022-29526)
[CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191)
