### PR TITLE
Wiz Remediate Vulnerabilities in: /go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
 )


### PR DESCRIPTION
Wiz has identified vulnerabilities in the following files: /go.mod. This PR contains remediations for these vulnerabilities.
### /go.mod
[CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948)
